### PR TITLE
chore: allow React 16.8.4 and higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.8.4 || ^17.0.0",
-    "react-dom": "^16.8.4 || ^17.0.0"
+    "react": ">=16.8.4",
+    "react-dom": ">=16.8.4"
   },
   "engines": {
     "node": ">=10.15.1"


### PR DESCRIPTION
Update the `peerDependencies` for React in preparation to upgrade the Framework docs site to React 18.